### PR TITLE
Fixed .gemspec

### DIFF
--- a/ruby-xslt.gemspec
+++ b/ruby-xslt.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{ruby-xslt}
-  s.version = "0.9.7"
+  s.version = "0.9.8"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Gregoire Lejeune"]


### PR DESCRIPTION
The file ruby-xslt.gemspec still had references to not existing files in examples/ directory. That causes bundler to not compile the C extensions when installing directly via git. 

I removed them and upped version to 0.9.8.

Cheers
Marc
